### PR TITLE
Refactor user endpoints to use JWT claims, add profile images

### DIFF
--- a/backend/backend/Controllers/AdminDriversController.cs
+++ b/backend/backend/Controllers/AdminDriversController.cs
@@ -35,8 +35,9 @@ namespace backend.Controllers
                         LicenseExpiryDate = d.Driver.LicenseExpiryDate,
                         IsActive = d.IsActive,
                         Notes = d.Driver.Notes,
-                        Id = d.Id
-                    }
+                        Id = d.Id,
+                        ProfileImgFileId = d.ProfileImgFileId
+                }
                 );
                 var q = query.StringQ?.Trim();
                 if (!string.IsNullOrWhiteSpace(q))

--- a/backend/backend/Controllers/AdminVehiclesController.cs
+++ b/backend/backend/Controllers/AdminVehiclesController.cs
@@ -33,7 +33,8 @@ namespace backend.Controllers
                     CurrentMileageKm = v.CurrentMileageKm,
                     Vin = v.Vin,
                     Status = v.Status,
-                    UserEmail = v.VehicleAssignments.Where(a => a.AssignedTo == null).Select(a => a.Driver.User.Email).FirstOrDefault()!
+                    UserEmail = v.VehicleAssignments.Where(a => a.AssignedTo == null).Select(a => a.Driver.User.Email).FirstOrDefault()!,
+                    ProfileImgFileId = v.VehicleAssignments.Where(a => a.AssignedTo == null).Select(a => a.Driver.User.ProfileImgFileId).FirstOrDefault()
                 });
                 var q = query.StringQ?.Trim();
                 if (!string.IsNullOrWhiteSpace(q))

--- a/backend/backend/Controllers/FilesController.cs
+++ b/backend/backend/Controllers/FilesController.cs
@@ -39,7 +39,7 @@ namespace backend.Controllers
                 return Unauthorized();
             ulong userId = ulong.Parse(userIdClaim);
             var id = await _fileService.SaveFileAsync(file, folder, userId);
-            return Ok(id);
+            return StatusCode(201, id);
         }
 
         [HttpGet("{id}")]

--- a/backend/backend/Controllers/NotificationController.cs
+++ b/backend/backend/Controllers/NotificationController.cs
@@ -22,7 +22,10 @@ namespace backend.Controllers
         [HttpGet]
         public async Task<IActionResult> GetMine()
         {
-            var userId = ulong.Parse(User.FindFirst(ClaimTypes.NameIdentifier)!.Value);
+            var userIdClaim = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+            if (userIdClaim == null)
+                return Unauthorized();
+            ulong userId = ulong.Parse(userIdClaim);
             var list = await _notificationService.GetUserNotificationsAsync(userId);
             return Ok(list);
         }
@@ -36,13 +39,16 @@ namespace backend.Controllers
                 dto.Title,
                 dto.Message,
                 dto.RelatedServiceRequestId);
-            return Ok();
+            return Created();
         }
 
         [HttpPatch("read")]
         public async Task<IActionResult> MarkRead()
         {
-            var userId = ulong.Parse(User.FindFirst(ClaimTypes.NameIdentifier)!.Value);
+            var userIdClaim = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+            if (userIdClaim == null)
+                return Unauthorized();
+            ulong userId = ulong.Parse(userIdClaim);
             await _notificationService.MarkAsReadAsync(userId);
             return NoContent();
         }
@@ -50,7 +56,10 @@ namespace backend.Controllers
         [HttpDelete("{id}")]
         public async Task<IActionResult> Delete(ulong id)
         {
-            var userId = ulong.Parse(User.FindFirst(ClaimTypes.NameIdentifier)!.Value);
+            var userIdClaim = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+            if (userIdClaim == null)
+                return Unauthorized();
+            ulong userId = ulong.Parse(userIdClaim);
             await _notificationService.DeleteAsync(id, userId);
             return NoContent();
         }
@@ -58,7 +67,10 @@ namespace backend.Controllers
         [HttpGet("unread-status")]
         public async Task<IActionResult> HasUnread()
         {
-            var userId = ulong.Parse(User.FindFirst(ClaimTypes.NameIdentifier)!.Value);
+            var userIdClaim = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+            if (userIdClaim == null)
+                return Unauthorized();
+            ulong userId = ulong.Parse(userIdClaim);
             var has = await _notificationService.HasUnreadNotifications(userId);
             return Ok(has);
         }

--- a/backend/backend/Dtos/FuelLogs/FuelLogDto.cs
+++ b/backend/backend/Dtos/FuelLogs/FuelLogDto.cs
@@ -9,6 +9,7 @@
         public string? StationName { get; set; }
         public ulong? ReceiptFileId { get; set; }
         public string UserEmail { get; set; } = "";
+        public ulong? ProfileImgFileId { get; set; }
         public string LicensePlate { get; set; } = "";
         public bool IsDeleted { get; set; }
     }

--- a/backend/backend/Dtos/Trips/TripDto.cs
+++ b/backend/backend/Dtos/Trips/TripDto.cs
@@ -4,6 +4,7 @@
     {
         public ulong Id { get; set; }
         public string UserEmail { get; set; } = "";
+        public ulong? ProfileImgFileId { get; set; }
         public string LicensePlate { get; set; } = "";
         public bool IsDeleted { get; set; }
         public DateTime StartTime { get; set; }

--- a/backend/backend/Dtos/Vehicles/VehiclesDto.cs
+++ b/backend/backend/Dtos/Vehicles/VehiclesDto.cs
@@ -9,6 +9,7 @@
         public int CurrentMileageKm { get; set; } = 0;
         public string? Vin { get; set; }
         public string UserEmail { get; set; } = "";
+        public ulong? ProfileImgFileId { get; set; }
         public string Status { get; set; } = "";
     }
 }


### PR DESCRIPTION
Refactored user-specific API endpoints to use the authenticated user's ID from JWT claims, removing user ID route parameters and introducing "mine" endpoints. Unified and simplified trip and fuel log endpoints and delete logic, restricting DRIVERs to delete only their own recent records. Extended DTOs to include ProfileImgFileId for displaying user images. Improved security checks for user claims, updated file upload responses to HTTP 201, and made minor bug fixes and consistency improvements.