### PR TITLE
Add cleanup background service and user thumbnail endpoint

### DIFF
--- a/backend/backend/Controllers/FilesController.cs
+++ b/backend/backend/Controllers/FilesController.cs
@@ -64,5 +64,15 @@ namespace backend.Controllers
                 return NoContent();
             });
         }
+
+        [HttpGet("thumbnail/{userId}")]
+        public async Task<IActionResult> GetUserThumbnail(ulong userId)
+        {
+            return await this.Run(async () =>
+            {
+                var result = await _fileService.GetUserThumbnailAsync(userId);
+                return File(result.Content, result.MimeType, enableRangeProcessing: true);
+            });
+        }
     }
 }

--- a/backend/backend/Program.cs
+++ b/backend/backend/Program.cs
@@ -23,6 +23,7 @@ namespace backend
                     throw new InvalidOperationException("Connection string 'DefaultConnection' not found.");
                 option.UseMySQL(coonectionString);
             });
+            builder.Services.AddHostedService<CleanupBackgroundService>();
             builder.Services.AddScoped<IFileService, FileService>();
             builder.Services.AddScoped<INotificationService, NotificationService>();
             builder.Services.AddControllers();

--- a/backend/backend/Services/CleanupBackgroundService.cs
+++ b/backend/backend/Services/CleanupBackgroundService.cs
@@ -1,0 +1,150 @@
+﻿using Microsoft.EntityFrameworkCore;
+
+namespace backend.Services
+{
+    public class CleanupBackgroundService : BackgroundService
+    {
+        private readonly IServiceScopeFactory _scopeFactory;
+        private readonly ILogger<CleanupBackgroundService> _logger;
+
+        public CleanupBackgroundService(IServiceScopeFactory scopeFactory, ILogger<CleanupBackgroundService> logger)
+        {
+            _scopeFactory = scopeFactory;
+            _logger = logger;
+        }
+
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            _logger.LogInformation("Cleanup service started");
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                try
+                {
+                    await RunCleanupAsync();
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex.Message, "Cleanup failed");
+                }
+                await Task.Delay(TimeSpan.FromHours(24), stoppingToken);
+            }
+        }
+
+        private async Task RunCleanupAsync()
+        {
+            using var scope = _scopeFactory.CreateScope();
+            var context = scope.ServiceProvider.GetRequiredService<FlottakezeloDbContext>();
+            var env = scope.ServiceProvider.GetRequiredService<IWebHostEnvironment>();
+            var limitDate = DateTime.UtcNow.AddDays(-90);
+            var deletedUsers = await context.Users.Where(u => u.UpdatedAt < limitDate && u.IsActive == false).ToListAsync();
+            if (deletedUsers.Count > 0)
+            {
+                var driverIds = deletedUsers.Select(u => u.Driver!.Id).ToList();
+                var usersIds = deletedUsers.Select(u => u.Id).ToList();
+                var notifications = await context.Notifications.Where(n => usersIds.Contains(n.UserId)).ToListAsync();
+                context.Notifications.RemoveRange(notifications);
+                var usersFuelLogs = await context.FuelLogs.Where(f => driverIds.Contains(f.DriverId)).ToListAsync();
+                context.FuelLogs.RemoveRange(usersFuelLogs);
+                var usersTrips = await context.Trips.Where(t => driverIds.Contains(t.DriverId)).ToListAsync();
+                context.Trips.RemoveRange(usersTrips);
+                var usersServiceRequests = await context.ServiceRequests.Where(s => usersIds.Contains(s.CreatedByDriverUserId)).ToListAsync();
+                context.ServiceRequests.RemoveRange(usersServiceRequests);
+                var calendarEvents = await context.CalendarEvents.Where(c => usersIds.Contains(c.OwnerUserId) || usersIds.Contains(c.CreatedByUserId)).ToListAsync();
+                context.CalendarEvents.RemoveRange(calendarEvents);
+                var drivers = await context.Drivers.Where(d => driverIds.Contains(d.Id)).ToListAsync();
+                context.Drivers.RemoveRange(drivers);
+                var files = await context.Files.Where(f => usersIds.Contains(f.UploadedByUserId)).ToListAsync();
+                foreach (var f in files)
+                {
+                    var file = await context.Files.FindAsync(f.Id);
+                    if (file != null)
+                    {
+                        var storageRoot = Path.Combine(env.ContentRootPath, "storage");
+                        var path = Directory.GetFiles(storageRoot, file.StoredName, SearchOption.AllDirectories).FirstOrDefault();
+                        if (path != null)
+                            File.Delete(path);
+                        context.Files.Remove(file);
+                    }
+                }
+            }
+            context.Users.RemoveRange(deletedUsers!);
+            var deletedVehicles = await context.Vehicles.Where(v => v.UpdatedAt < limitDate && v.Status == "RETIRED").ToListAsync();
+            if (deletedVehicles.Count > 0)            {
+                var vehicleIds = deletedVehicles.Select(v => v.Id).ToList();
+                var vehicleServiceRequests = await context.ServiceRequests.Where(s => vehicleIds.Contains(s.VehicleId)).ToListAsync();
+                context.ServiceRequests.RemoveRange(vehicleServiceRequests);
+                var vehicleServiceRequestNotifications = await context.Notifications.Where(n => n.RelatedServiceRequestId != null && vehicleServiceRequests.Select(s => s.Id).Contains(n.RelatedServiceRequestId.Value)).ToListAsync();
+                context.Notifications.RemoveRange(vehicleServiceRequestNotifications);
+                var vehicleTrips = await context.Trips.Where(t => vehicleIds.Contains(t.VehicleId)).ToListAsync();
+                context.Trips.RemoveRange(vehicleTrips);
+                var vehicleFuelLogs = await context.FuelLogs.Where(f => vehicleIds.Contains(f.VehicleId)).ToListAsync();
+                context.FuelLogs.RemoveRange(vehicleFuelLogs);
+                var calendarEvents = await context.CalendarEvents.Where(c => c.RelatedServiceRequestId != null && vehicleServiceRequests.Select(s => s.Id).Contains(c.RelatedServiceRequestId.Value)).ToListAsync();
+                context.CalendarEvents.RemoveRange(calendarEvents);
+                foreach (var f in vehicleFuelLogs)
+                {
+                    var file = await context.Files.FindAsync(f.ReceiptFileId);
+                    if (file != null)
+                    {
+                        var storageRoot = Path.Combine(env.ContentRootPath, "storage");
+                        var path = Directory.GetFiles(storageRoot, file.StoredName, SearchOption.AllDirectories).FirstOrDefault();
+                        if (path != null)
+                            File.Delete(path);
+                        context.Files.Remove(file);
+                    }
+                }
+                foreach (var s in vehicleServiceRequests)
+                {
+                    var file = await context.Files.FindAsync(s.InvoiceFileId);
+                    if (file != null)
+                    {
+                        var storageRoot = Path.Combine(env.ContentRootPath, "storage");
+                        var path = Directory.GetFiles(storageRoot, file.StoredName, SearchOption.AllDirectories).FirstOrDefault();
+                        if (path != null)
+                            File.Delete(path);
+                        context.Files.Remove(file);
+                    }
+                }
+            }
+            context.Vehicles.RemoveRange(deletedVehicles);
+            var deletedServiceRequests = await context.ServiceRequests.Where(s => s.ClosedAt < limitDate).ToListAsync();
+            context.ServiceRequests.RemoveRange(deletedServiceRequests);
+            var serviceRequestNotifications = await context.Notifications.Where(n => n.RelatedServiceRequestId != null && deletedServiceRequests.Select(s => s.Id).Contains(n.RelatedServiceRequestId.Value)).ToListAsync();
+            context.Notifications.RemoveRange(serviceRequestNotifications);
+            var serviceRequestCalendarEvents = await context.CalendarEvents.Where(c => c.RelatedServiceRequestId != null && deletedServiceRequests.Select(s => s.Id).Contains(c.RelatedServiceRequestId.Value)).ToListAsync();
+            context.CalendarEvents.RemoveRange(serviceRequestCalendarEvents);
+            foreach (var s in deletedServiceRequests)
+            {
+                var file = await context.Files.FindAsync(s.InvoiceFileId);
+                if (file != null)
+                {
+                    var storageRoot = Path.Combine(env.ContentRootPath, "storage");
+                    var path = Directory.GetFiles(storageRoot, file.StoredName, SearchOption.AllDirectories).FirstOrDefault();
+                    if (path != null)
+                        File.Delete(path);
+                    context.Files.Remove(file);
+                }
+            }
+            var deltedFuelLogs = await context.FuelLogs.Where(f => f.UpdatedAt < limitDate && f.IsDeleted == true).ToListAsync();
+            context.FuelLogs.RemoveRange(deltedFuelLogs);
+            foreach (var f in deltedFuelLogs)
+            {
+                var file = await context.Files.FindAsync(f.ReceiptFileId);
+                if (file != null)
+                {
+                    var storageRoot = Path.Combine(env.ContentRootPath, "storage");
+                    var path = Directory.GetFiles(storageRoot, file.StoredName, SearchOption.AllDirectories).FirstOrDefault();
+                    if (path != null)
+                        File.Delete(path);
+                    context.Files.Remove(file);
+                }
+            }
+            var deletedTrips = await context.Trips.Where(t => t.UpdatedAt < limitDate && t.IsDeleted == true).ToListAsync();
+            context.Trips.RemoveRange(deletedTrips);
+            var oldNotifications = await context.Notifications.Where(n => n.CreatedAt < limitDate).ToListAsync();
+            context.Notifications.RemoveRange(oldNotifications);
+            await context.SaveChangesAsync();
+            _logger.LogInformation("Cleanup executed at {time}", DateTime.UtcNow);
+        }
+    }
+}

--- a/backend/backend/Services/Interfaces/IFileService.cs
+++ b/backend/backend/Services/Interfaces/IFileService.cs
@@ -5,5 +5,6 @@
         Task<ulong> SaveFileAsync(IFormFile file, string folder, ulong uploadedByUserId);
         Task<(byte[] Content, string MimeType, string FileName)> GetFileAsync(ulong id);
         Task DeleteFileAsync(ulong id);
+        Task<(byte[] Content, string MimeType)> GetUserThumbnailAsync(ulong userId);
     }
 }

--- a/backend/backend/backend.csproj
+++ b/backend/backend/backend.csproj
@@ -14,6 +14,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="MySql.EntityFrameworkCore" Version="10.0.1" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.12" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
   </ItemGroup>
 


### PR DESCRIPTION
Introduce CleanupBackgroundService to periodically remove old/deleted users, vehicles, and related data/files. Add GET /api/files/thumbnail/{userId} endpoint to serve 64x64 cropped JPEG user profile thumbnails using ImageSharp. Update FileService and IFileService accordingly, and improve file reading with streams. Add ImageSharp dependency.